### PR TITLE
Update the package list & fix an attribute typo

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -16,6 +16,7 @@ supports 'ubuntu', '= 10.04'
 supports 'ubuntu', '= 12.04'
 supports 'ubuntu', '= 14.04'
 
+depends 'apt'
 depends 'ark'
 depends 'build-essential'
 depends 'chef-sugar'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -9,7 +9,10 @@
 include_recipe 'chef-sugar::default'
 include_recipe 'java::default'
 
-node.set['build-essential']['compile_tile'] = true
+node.set['apt']['compile_time_update'] = true
+node.set['build-essential']['compile_time'] = true
+
+include_recipe 'apt' if platform_family?('debian')
 include_recipe 'build-essential::default'
 
 directory node['jmeter']['plan_dir'] do


### PR DESCRIPTION
On a Ubuntu node on EC2, the apt repository needed to be updated & refreshed in order to install packages.

Also, there was a typo in the build-essential attribute.
